### PR TITLE
Clean up sample artifacts and add generator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.html
 __pycache__/
 *.zip
+
+data.csv
+zips.*

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ archives are no longer included in the repository. Running
 embedded in the script. You can also fetch them manually from the project's
 GitHub release page if you prefer to run the examples offline.
 
+For quick testing of `choropleth_by_spend.py` without downloading large files,
+run `generate_sample_inputs.py` to create a tiny shapefile and matching CSV. The
+script outputs `sample_geometry.zip` and `sample_data.zip` in the current
+directory, which you can then pass to the heatmap script.
+
 ## Usage
 
 The `choropleth_by_spend.py` script expects two zip files. These can be local
@@ -47,6 +52,15 @@ python3 choropleth_by_spend.py \
   https://raw.githubusercontent.com/user/repo/main/geometry.zip \
   https://raw.githubusercontent.com/user/repo/main/data.zip \
   output.html
+```
+
+If you generated the small test inputs with `generate_sample_inputs.py`, invoke
+the script as follows:
+
+```bash
+python3 generate_sample_inputs.py
+python3 choropleth_by_spend.py sample_geometry.zip sample_data.zip output.html \
+    --geometry-zip-field ZCTA5CE10 --data-zip-field zip --spend-field spend
 ```
 
 The resulting `output.html` is an interactive choropleth showing spend by ZIP

--- a/generate_sample_inputs.py
+++ b/generate_sample_inputs.py
@@ -1,0 +1,40 @@
+import zipfile
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Polygon
+
+zips = [
+    ("30301", (33.75, -84.39)),
+    ("78701", (30.27, -97.74)),
+    ("10001", (40.75, -73.99)),
+    ("90001", (33.97, -118.25)),
+    ("98101", (47.61, -122.33)),
+]
+
+polys = []
+for z, (lat, lon) in zips:
+    polys.append({
+        "ZCTA5CE10": z,
+        "geometry": Polygon([
+            (lon - 0.05, lat - 0.05),
+            (lon + 0.05, lat - 0.05),
+            (lon + 0.05, lat + 0.05),
+            (lon - 0.05, lat + 0.05),
+        ])
+    })
+
+gdf = gpd.GeoDataFrame(polys, crs="EPSG:4326")
+gdf.to_file("zips.shp")
+
+with zipfile.ZipFile("sample_geometry.zip", "w") as zf:
+    for ext in ["shp", "shx", "dbf", "cpg", "prj"]:
+        zf.write(f"zips.{ext}")
+
+# Create sample data csv
+pdf = pd.DataFrame({"zip": [z for z, _ in zips], "spend": [100, 200, 150, 250, 180]})
+pdf.to_csv("data.csv", index=False)
+
+with zipfile.ZipFile("sample_data.zip", "w") as zf:
+    zf.write("data.csv")
+
+print("Generated sample_geometry.zip and sample_data.zip")


### PR DESCRIPTION
## Summary
- remove output HTML and example zip archives
- generate test inputs with `generate_sample_inputs.py`
- document how to create these sample files in README
- ignore intermediate files

## Testing
- `python3 generate_sample_inputs.py`
- `python3 choropleth_by_spend.py sample_geometry.zip sample_data.zip output.html --geometry-zip-field ZCTA5CE10 --data-zip-field zip --spend-field spend`


------
https://chatgpt.com/codex/tasks/task_e_684c520fbc40832ca4da727586c6b990