### PR TITLE
Add pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        args: ["--line-length", "79"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+

--- a/README.md
+++ b/README.md
@@ -114,3 +114,16 @@ The script uses default URLs for the two zip archives and the ZIP‑to‑coordin
 CSV, so running the command above will create `client_map.html` with sample
 data. Pass `--zip1`, `--zip2` or `--zip-latlon` to override these sources with
 local paths or alternate links.
+
+## Contributing
+
+Install the `pre-commit` tool and set up the hooks so formatting and linting
+run automatically on each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hooks invoke `black --line-length 79` and `flake8` to keep the codebase
+consistent.


### PR DESCRIPTION
## Summary
- format/lint with black and flake8 via pre-commit
- document how to enable the hooks

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6861ad926ba8832ca8474a6cfc94b0a6